### PR TITLE
Remove site footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,18 @@
+<!-- 
+<footer class="site-footer h-card">
+	<div class="wrapper">
+
+		<div class="footer-col-wrapper">
+			<div class="footer-col one-half">
+				<p>{{ site.title | escape }}</p>
+			</div>
+
+			<div class="footer-col one-half">
+				<p>{%- include social.html -%}</p>
+			</div>
+		</div>
+
+	</div>
+
+</footer> 
+-->

--- a/index.md
+++ b/index.md
@@ -7,6 +7,7 @@ $ npm install --save sequelize
 ```
 
 ## Security
+
 Please follow responsible disclosure guidelines from [SECURITY.md](https://github.com/sequelize/sequelize/blob/master/SECURITY.md)
 
 ## Documentation
@@ -15,6 +16,7 @@ Please follow responsible disclosure guidelines from [SECURITY.md](https://githu
 - [v3 Documentation](https://sequelize.org/v3)
 
 ## Resources
+- [GitHub](https://github.com/sequelize/sequelize/)
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Slack](http://sequelize-slack.herokuapp.com/)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/sequelize.js)


### PR DESCRIPTION
The current site footer has no useful info.
This commit removes it, and adds a link to the GitHub
repo to the list of resources on the index page.