### PR TITLE
build: add v6 and change master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 *NOTE: Do not send pull requests to this repository. Send them to the [main repository](https://github.com/sequelize/sequelize) instead.*
 
+### docs based on the main branch:
+https://sequelize.org/main
+
 ### v6 docs:
-https://sequelize.org/master
+https://sequelize.org/v6
 
 ### v5 docs:
 https://sequelize.org/v5

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,8 @@
         </label>
 
         <div class="trigger">
-          <a class="page-link external-link" href="https://sequelize.org/master">v6</a>
+          <a class="page-link external-link" href="https://sequelize.org/main">main</a>
+          <a class="page-link external-link" href="https://sequelize.org/v6">v6</a>
           <a class="page-link external-link" href="https://sequelize.org/v5">v5</a>
           <a class="page-link external-link" href="https://sequelize.org/v4">v4</a>
           <a class="page-link external-link" href="https://sequelize.org/v3">v3</a>

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ build_branch () {
         mv ./site ../$BUILD_DIR/$1
     else
         if [ $1 == "main" ]; then
-          mv ./esdoc ../$BUILD_DIR/master
+          mv ./esdoc ../$BUILD_DIR/main
         else
           mv ./esdoc ../$BUILD_DIR/$1
         fi
@@ -28,6 +28,7 @@ git clone $CLONE_URL
 cd $REPO_NAME
 
 build_branch main
+build_branch v6
 build_branch v5
 build_branch v4
 build_branch v3

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ build_branch () {
         mv ./site ../$BUILD_DIR/$1
     else
         if [ $1 == "main" ]; then
+          cp ./esdoc ../$BUILD_DIR/master
           mv ./esdoc ../$BUILD_DIR/main
         else
           mv ./esdoc ../$BUILD_DIR/$1

--- a/index.md
+++ b/index.md
@@ -8,10 +8,11 @@ $ npm install --save sequelize
 
 ## Security
 
-Please follow responsible disclosure guidelines from [SECURITY.md](https://github.com/sequelize/sequelize/blob/master/SECURITY.md)
+Please follow responsible disclosure guidelines from [SECURITY.md](https://github.com/sequelize/sequelize/blob/main/SECURITY.md)
 
 ## Documentation
-- [v6 Documentation](https://sequelize.org/master/)
+- [Documentation main branch](https://sequelize.org/main/)
+- [v6 Documentation](https://sequelize.org/v6)
 - [v5 Documentation](https://sequelize.org/v5)
 - [v4 Documentation](https://sequelize.org/v4)
 - [v3 Documentation](https://sequelize.org/v3)


### PR DESCRIPTION
Not too happy yet, I want /master to redirect to /main but I don't know how to do that here without copying files there as well. I'm not familiar with github-pages

But I have a general remark as well; do we even need the documentation based on the main branch? It might be better to only include documentation of versions that have been released. So this PR is open to further discussion